### PR TITLE
Handle incorrect scheme when accessing via ngrok

### DIFF
--- a/voice/record-a-message/composer.json
+++ b/voice/record-a-message/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
-        "slim/slim": "^3.8"
+        "slim/slim": "^3.8",
+        "akrabat/rka-scheme-and-host-detection-middleware": "^0.3"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.1"

--- a/voice/record-a-message/composer.lock
+++ b/voice/record-a-message/composer.lock
@@ -1,11 +1,59 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4780cd09dd39e466a7e82975bae3ac5d",
+    "content-hash": "fdf33e37489adc30aa6fef89019412b9",
     "packages": [
+        {
+            "name": "akrabat/rka-scheme-and-host-detection-middleware",
+            "version": "0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/akrabat/rka-scheme-and-host-detection-middleware.git",
+                "reference": "5b5e9668d3291ffeafe487ffc00b5344b945a369"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/akrabat/rka-scheme-and-host-detection-middleware/zipball/5b5e9668d3291ffeafe487ffc00b5344b945a369",
+                "reference": "5b5e9668d3291ffeafe487ffc00b5344b945a369",
+                "shasum": ""
+            },
+            "require": {
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8",
+                "squizlabs/php_codesniffer": "^2.3",
+                "zendframework/zend-diactoros": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RKA\\Middleware\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Allen",
+                    "email": "rob@akrabat.com",
+                    "homepage": "http://akrabat.com"
+                }
+            ],
+            "description": "PSR-7 Middleware that determines the scheme, host and port from the 'X-Forwarded-Proto', 'X-Forwarded-Host' and 'X-Forwarded-Port' headers and updates the Request's Uri object.",
+            "homepage": "http://github.com/akrabat/rka-scheme-and-host-detection-middleware",
+            "keywords": [
+                "IP",
+                "middleware",
+                "psr7"
+            ],
+            "time": "2016-11-13T11:55:26+00:00"
+        },
         {
             "name": "container-interop/container-interop",
             "version": "1.2.0",

--- a/voice/record-a-message/index.php
+++ b/voice/record-a-message/index.php
@@ -6,8 +6,14 @@ require 'vendor/autoload.php';
 
 $app = new \Slim\App;
 
+$app->add(new RKA\Middleware\SchemeAndHost());
+
 $app->get('/webhooks/answer', function (Request $request, Response $response) {
     $uri = $request->getUri();
+    $event_url = $uri->getScheme().'://'.$uri->getHost().'/webhooks/recording';
+    if($uri->getPort()) {
+        $event_url = $uri->getScheme().'://'.$uri->getHost().':'.$uri->getPort().'/webhooks/recording';
+    }
     $ncco = [
         [
             'action' => 'talk',
@@ -17,7 +23,7 @@ $app->get('/webhooks/answer', function (Request $request, Response $response) {
         [
             'action' => 'record',
             'eventUrl' => [
-                $uri->getScheme().'://'.$uri->getHost().':'.$uri->getPort().'/webhooks/recording'
+                $event_url
             ],
             'endOnSilence' => '3',
             'endOnKey' => '#',


### PR DESCRIPTION
When switching between using this example directly on http://localhost:8080 and the same but with ngrok in front https://somethingsomething.ngrok.io then we lose the scheme* and it always assumes HTTP, not HTTPS, because it ignores the HTTP_X_FORWARDED_PROTO for security reasons. For this situation, where we want to support the header, we can use https://github.com/akrabat/rka-scheme-and-host-detection-middleware.

This pull request adds it for the `record-a-message` building block only, but if we agree this is useful, I'll roll it out for the others (4 or 5 others in the voice folder using Slim are affected I think , it's basically when we need to build a URL in an NCCO).

* Actually we also get the wrong port number, but I think that's a Slim bug and have opened an issue/PR with them and am leaving our code as it is for now (see https://github.com/slimphp/Slim/issues/2486)