### PR TITLE
Corrected README to link to  as previous URL was 404ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Please [raise an issue](/../../issues/) to request an example that isn't present
 
 ## Licenses
 
-- The sample code in this repo is licensed under [MIT](LICENSE)
+- The sample code in this repo is licensed under [MIT](LICENSE.md)
 
   ​


### PR DESCRIPTION
The link was returning a 404. So fixed the `README.md` to link to the correct file.