### PR TITLE
Updated receive sms with slim

### DIFF
--- a/sms/receive-with-slim/composer.json
+++ b/sms/receive-with-slim/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
-        "slim/slim": "^3.8",
-        "vonage/client": "^2.3"
+        "slim/slim": "4.*",
+        "vonage/client": "^2.4"
     },
     "scripts":{
         "serve": "php -S 0.0.0.0:3000 index.php"

--- a/sms/receive-with-slim/index.php
+++ b/sms/receive-with-slim/index.php
@@ -1,15 +1,15 @@
 <?php
 use \Psr\Http\Message\ServerRequestInterface as Request;
 use \Psr\Http\Message\ResponseInterface as Response;
+use Slim\Factory\AppFactory;
 
 require 'vendor/autoload.php';
 
-$app = new \Slim\App;
+$app = AppFactory::create();
 
 $handler = function (Request $request, Response $response) {
     $sms = \Vonage\SMS\Webhook\Factory::createFromRequest($request);
-
-    error_log(print_r($sms, true));
+    error_log('From: ' . $sms->getMsisdn() . ' message: ' . $sms->getText());
 
     return $response->withStatus(204);
 };


### PR DESCRIPTION
I'm working my way through building Youtube XwithYs, this is the next one in my sights. I've updated the Receive SMS with Slim example to use a newer version of Slim because the differences in how the framework is used vary quite a bit.

I've also updated the logged output to rather than output the class fields, instead follow: https://github.com/Nexmo/code-snippet-specs/blob/master/sms/receive-sms.md 

Which is to output the msisdn and text: eg 

```console.log(`from: ${params.msisdn}, message: ${params.message}`)```

For PHP becomes:

```error_log('From: ' . $sms->getMsisdn() . ' message: ' . $sms->getText());```