### PR TITLE
Automatic Unicode detection docs change

### DIFF
--- a/sms/send-unicode-sms.php
+++ b/sms/send-unicode-sms.php
@@ -7,7 +7,5 @@ $basic  = new \Vonage\Client\Credentials\Basic(VONAGE_API_KEY, VONAGE_API_SECRET
 $client = new \Vonage\Client($basic);
 
 $response = $client->sms()->send(
-    new \Vonage\SMS\Message\SMS(TO_NUMBER, BRAND_NAME, 'こんにちは世界')
+    new \Vonage\SMS\Message\SMS(TO_NUMBER, BRAND_NAME, 'こんにちは世界', 'unicode')
 );
-
-var_dump($response->current());


### PR DESCRIPTION
The default type of SMS is set to unicode, but you can also set it in the SMS object constructor in line with the other SDKs