### PR TITLE
DEVX-6440: Updating whatsapp template snippets

### DIFF
--- a/messages/whatsapp/send-media-mtm.php
+++ b/messages/whatsapp/send-media-mtm.php
@@ -33,9 +33,9 @@ $custom = [
             [
                 "type" => "body",
                 "parameters" => [
-                    ["type" => "text", "text" => "Value 1"],
-                    ["type" => "text", "text" => "Value 2"],
-                    ["type" => "text", "text" => "Value 3"],
+                    "Value 1",
+                    "Value 2",
+                    "Value 3",
                 ],
             ],
         ],

--- a/messages/whatsapp/send-mtm.php
+++ b/messages/whatsapp/send-mtm.php
@@ -12,9 +12,9 @@ $client = new \Vonage\Client($keypair);
 $custom = [
     "name" => WHATSAPP_TEMPLATE_NAMESPACE . ":" . WHATSAPP_TEMPLATE_NAME,
     "parameters" => [
-        ["default" => "Vonage Verification"],
-        ["default" => "64873"],
-        ["default" => "10"],
+        "Vonage Verification",
+        "64873",
+        "10",
     ],
 ];
 


### PR DESCRIPTION
Small change to the snippets for sending WhatsApp Template messages. The value for the `parameters` field was incorrect due to an error in the spec.